### PR TITLE
fix: potential serialization error due to non-transient field inside a serializable class

### DIFF
--- a/api/src/main/java/jakarta/activation/MimeType.java
+++ b/api/src/main/java/jakarta/activation/MimeType.java
@@ -24,7 +24,7 @@ public class MimeType implements Externalizable {
 
     private String primaryType;
     private String subType;
-    private MimeTypeParameterList parameters;
+    private transient MimeTypeParameterList parameters;
 
     private static final long serialVersionUID = 7548163901563814301L;
 


### PR DESCRIPTION
In file: MimeType.java, the serializable class MimeType contains a non-serializable field. In this case, serialization of the class can lead to a NotSerializableException. To learn more check [CWE 594](https://cwe.mitre.org/data/definitions/594)  and also more explanation and its side effects are briefly explained [here: What Happens When A Serializable Object Contains a Non-Serializable Field?](https://www.openrefactory.com/crash-boom-bang-what-happens-when-a-serializable-object-contains-a-non-serializable-field/#:~:text=scenario%201%3A%20reference%20of%20non-serializable%20object%20inside%20a%20serializable%20object)

## Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.