### PR TITLE
Remove SecurityManager related code from API

### DIFF
--- a/api/src/main/java/jakarta/activation/CommandInfo.java
+++ b/api/src/main/java/jakarta/activation/CommandInfo.java
@@ -16,8 +16,6 @@ import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 /**
  * The CommandInfo class is used by CommandMap implementations to
@@ -171,34 +169,12 @@ public class CommandInfo {
 
             } else {
 
-                SecurityManager security = System.getSecurityManager();
-                if (security != null) {
-                    // if it's ok with the SecurityManager, it's ok with me.
-                    String cname = cn.replace('/', '.');
-                    if (cname.startsWith("[")) {
-                        int b = cname.lastIndexOf('[') + 2;
-                        if (b > 1 && b < cname.length()) {
-                            cname = cname.substring(b);
-                        }
-                    }
-                    int i = cname.lastIndexOf('.');
-                    if (i != -1) {
-                        security.checkPackageAccess(cname.substring(0, i));
-                    }
-                }
-
                 // Beans.instantiate specified to use SCL when loader is null
                 if (loader == null) {
-                    loader = AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
-                        public ClassLoader run() {
-                            ClassLoader cl = null;
-                            try {
-                                cl = ClassLoader.getSystemClassLoader();
-                            } catch (SecurityException ex) {
-                            }
-                            return cl;
-                        }
-                    });
+                    try {
+                        loader = ClassLoader.getSystemClassLoader();
+                    } catch (SecurityException ex) {
+                    }
                 }
                 Class<?> beanClass = Class.forName(cn, true, loader);
                 try {

--- a/api/src/main/java/jakarta/activation/CommandMap.java
+++ b/api/src/main/java/jakarta/activation/CommandMap.java
@@ -54,7 +54,7 @@ public abstract class CommandMap {
             return defaultCommandMap;
 
         // fetch per-thread-context-class-loader default
-        ClassLoader tccl = SecuritySupport.getContextClassLoader();
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
         CommandMap def = map.get(tccl);
         if (def == null) {
             def = new MailcapCommandMap();
@@ -72,24 +72,8 @@ public abstract class CommandMap {
      *                           to change the default
      */
     public static synchronized void setDefaultCommandMap(CommandMap commandMap) {
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            try {
-                // if it's ok with the SecurityManager, it's ok with me...
-                security.checkSetFactory();
-            } catch (SecurityException ex) {
-                // otherwise, we also allow it if this code and the
-                // factory come from the same (non-system) class loader (e.g.,
-                // the JAF classes were loaded with the applet classes).
-                ClassLoader cl = CommandMap.class.getClassLoader();
-                if (cl == null || cl.getParent() == null ||
-                        cl != commandMap.getClass().getClassLoader()) {
-                    throw ex;
-                }
-            }
-        }
         // remove any per-thread-context-class-loader CommandMap
-        map.remove(SecuritySupport.getContextClassLoader());
+        map.remove(Thread.currentThread().getContextClassLoader());
         defaultCommandMap = commandMap;
     }
 

--- a/api/src/main/java/jakarta/activation/DataHandler.java
+++ b/api/src/main/java/jakarta/activation/DataHandler.java
@@ -529,7 +529,7 @@ public class DataHandler {
             // make the bean
             ClassLoader cld = null;
             // First try the "application's" class loader.
-            cld = SecuritySupport.getContextClassLoader();
+            cld = Thread.currentThread().getContextClassLoader();
             if (cld == null)
                 cld = this.getClass().getClassLoader();
             bean = cmdinfo.getCommandObject(this, cld);
@@ -634,20 +634,6 @@ public class DataHandler {
         if (factory != null)
             throw new Error("DataContentHandlerFactory already defined");
 
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            try {
-                // if it's ok with the SecurityManager, it's ok with me...
-                security.checkSetFactory();
-            } catch (SecurityException ex) {
-                // otherwise, we also allow it if this code and the
-                // factory come from the same class loader (e.g.,
-                // the JAF classes were loaded with the applet classes).
-                if (DataHandler.class.getClassLoader() !=
-                        newFactory.getClass().getClassLoader())
-                    throw ex;
-            }
-        }
         factory = newFactory;
     }
 }

--- a/api/src/main/java/jakarta/activation/FileTypeMap.java
+++ b/api/src/main/java/jakarta/activation/FileTypeMap.java
@@ -80,23 +80,8 @@ public abstract class FileTypeMap {
      *                           to change the default
      */
     public static synchronized void setDefaultFileTypeMap(FileTypeMap fileTypeMap) {
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            try {
-                // if it's ok with the SecurityManager, it's ok with me...
-                security.checkSetFactory();
-            } catch (SecurityException ex) {
-                // otherwise, we also allow it if this code and the
-                // factory come from the same (non-system) class loader (e.g.,
-                // the JAF classes were loaded with the applet classes).
-                ClassLoader cl = FileTypeMap.class.getClassLoader();
-                if (cl == null || cl.getParent() == null ||
-                        cl != fileTypeMap.getClass().getClassLoader())
-                    throw ex;
-            }
-        }
         // remove any per-thread-context-class-loader FileTypeMap
-        map.remove(SecuritySupport.getContextClassLoader());
+        map.remove(Thread.currentThread().getContextClassLoader());
         defaultMap = fileTypeMap;
     }
 
@@ -114,7 +99,7 @@ public abstract class FileTypeMap {
             return defaultMap;
 
         // fetch per-thread-context-class-loader default
-        ClassLoader tccl = SecuritySupport.getContextClassLoader();
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
         FileTypeMap def = map.get(tccl);
         if (def == null) {
             def = new MimetypesFileTypeMap();

--- a/api/src/main/java/jakarta/activation/MimetypesFileTypeMap.java
+++ b/api/src/main/java/jakarta/activation/MimetypesFileTypeMap.java
@@ -17,8 +17,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.NoSuchElementException;
 import java.util.ServiceConfigurationError;
 import java.util.Vector;
@@ -76,18 +74,11 @@ public class MimetypesFileTypeMap extends FileTypeMap {
     static {
         String dir = null;
         try {
-            dir = AccessController.doPrivileged(
-                    new PrivilegedAction<String>() {
-                        public String run() {
-                            String home = System.getProperty("java.home");
-                            String newdir = home + File.separator + "conf";
-                            File conf = new File(newdir);
-                            if (conf.exists())
-                                return newdir + File.separator;
-                            else
-                                return home + File.separator + "lib" + File.separator;
-                        }
-                    });
+            String home = System.getProperty("java.home");
+            String newdir = home + File.separator + "conf";
+            File conf = new File(newdir);
+            dir = conf.exists() ? (newdir + File.separator) :
+                (home + File.separator + "lib" + File.separator);
         } catch (Exception ex) {
             if (LogSupport.isLoggable())
                 LogSupport.log("Exception during MimetypesFileTypeMap class loading", ex);
@@ -151,7 +142,7 @@ public class MimetypesFileTypeMap extends FileTypeMap {
     private MimeTypeRegistry loadResource(String name) {
         InputStream clis = null;
         try {
-            clis = SecuritySupport.getResourceAsStream(this.getClass(), name);
+            clis = this.getClass().getResourceAsStream(name);
             if (clis != null) {
                 MimeTypeRegistry mf = getImplementation().getByInputStream(clis);
                 if (LogSupport.isLoggable())
@@ -192,7 +183,7 @@ public class MimetypesFileTypeMap extends FileTypeMap {
             URL[] urls;
             ClassLoader cld = null;
             // First try the "application's" class loader.
-            cld = SecuritySupport.getContextClassLoader();
+            cld = Thread.currentThread().getContextClassLoader();
             if (cld == null)
                 cld = this.getClass().getClassLoader();
             if (cld != null)
@@ -208,7 +199,7 @@ public class MimetypesFileTypeMap extends FileTypeMap {
                     if (LogSupport.isLoggable())
                         LogSupport.log("MimetypesFileTypeMap: URL " + url);
                     try {
-                        clis = SecuritySupport.openStream(url);
+                        clis = url.openStream();
                         if (clis != null) {
                             v.addElement(
                                     getImplementation().getByInputStream(clis)
@@ -395,15 +386,7 @@ public class MimetypesFileTypeMap extends FileTypeMap {
     }
 
     private MimeTypeRegistryProvider getImplementation() {
-        if (System.getSecurityManager() != null) {
-            return AccessController.doPrivileged(new PrivilegedAction<MimeTypeRegistryProvider>() {
-                public MimeTypeRegistryProvider run() {
-                    return FactoryFinder.find(MimeTypeRegistryProvider.class);
-                }
-            });
-        } else {
-            return FactoryFinder.find(MimeTypeRegistryProvider.class);
-        }
+        return FactoryFinder.find(MimeTypeRegistryProvider.class);
     }
 
     /*

--- a/api/src/main/java/jakarta/activation/SecuritySupport.java
+++ b/api/src/main/java/jakarta/activation/SecuritySupport.java
@@ -13,10 +13,6 @@ package jakarta.activation;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -30,87 +26,41 @@ class SecuritySupport {
         // private constructor, can't create an instance
     }
 
-    public static ClassLoader getContextClassLoader() {
-        return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
-            public ClassLoader run() {
-                ClassLoader cl = null;
-                try {
-                    cl = Thread.currentThread().getContextClassLoader();
-                } catch (SecurityException ex) {
-                }
-                return cl;
-            }
-        });
-    }
-
-    public static InputStream getResourceAsStream(final Class<?> c,
-                                                  final String name) throws IOException {
-        try {
-            return AccessController.doPrivileged(new PrivilegedExceptionAction<InputStream>() {
-                public InputStream run() throws IOException {
-                    return c.getResourceAsStream(name);
-                }
-            });
-        } catch (PrivilegedActionException e) {
-            throw (IOException) e.getException();
-        }
-    }
-
     public static URL[] getResources(final ClassLoader cl, final String name) {
-        return AccessController.doPrivileged(new PrivilegedAction<URL[]>() {
-            public URL[] run() {
-                URL[] ret = null;
-                try {
-                    List<URL> v = new ArrayList<>();
-                    Enumeration<URL> e = cl.getResources(name);
-                    while (e != null && e.hasMoreElements()) {
-                        URL url = e.nextElement();
-                        if (url != null)
-                            v.add(url);
-                    }
-                    if (v.size() > 0) {
-                        ret = new URL[v.size()];
-                        ret = v.toArray(ret);
-                    }
-                } catch (IOException | SecurityException ioex) {
-                }
-                return ret;
+        URL[] ret = null;
+        try {
+            List<URL> v = new ArrayList<>();
+            Enumeration<URL> e = cl.getResources(name);
+            while (e != null && e.hasMoreElements()) {
+                URL url = e.nextElement();
+                if (url != null)
+                    v.add(url);
             }
-        });
+            if (v.size() > 0) {
+                ret = new URL[v.size()];
+                ret = v.toArray(ret);
+            }
+        } catch (IOException | SecurityException ioex) {
+        }
+        return ret;
     }
 
     public static URL[] getSystemResources(final String name) {
-        return AccessController.doPrivileged(new PrivilegedAction<URL[]>() {
-            public URL[] run() {
-                URL[] ret = null;
-                try {
-                    List<URL> v = new ArrayList<>();
-                    Enumeration<URL> e = ClassLoader.getSystemResources(name);
-                    while (e != null && e.hasMoreElements()) {
-                        URL url = e.nextElement();
-                        if (url != null)
-                            v.add(url);
-                    }
-                    if (v.size() > 0) {
-                        ret = new URL[v.size()];
-                        ret = v.toArray(ret);
-                    }
-                } catch (IOException | SecurityException ioex) {
-                }
-                return ret;
-            }
-        });
-    }
-
-    public static InputStream openStream(final URL url) throws IOException {
+        URL[] ret = null;
         try {
-            return AccessController.doPrivileged(new PrivilegedExceptionAction<InputStream>() {
-                public InputStream run() throws IOException {
-                    return url.openStream();
-                }
-            });
-        } catch (PrivilegedActionException e) {
-            throw (IOException) e.getException();
+            List<URL> v = new ArrayList<>();
+            Enumeration<URL> e = ClassLoader.getSystemResources(name);
+            while (e != null && e.hasMoreElements()) {
+                URL url = e.nextElement();
+                if (url != null)
+                    v.add(url);
+            }
+            if (v.size() > 0) {
+                ret = new URL[v.size()];
+                ret = v.toArray(ret);
+            }
+        } catch (IOException | SecurityException ioex) {
         }
+        return ret;
     }
 }

--- a/api/src/main/java/jakarta/activation/ServiceLoaderUtil.java
+++ b/api/src/main/java/jakarta/activation/ServiceLoaderUtil.java
@@ -43,17 +43,6 @@ class ServiceLoaderUtil {
         return null;
     }
 
-    static void checkPackageAccess(String className) {
-        // make sure that the current thread has an access to the package of the given name.
-        SecurityManager s = System.getSecurityManager();
-        if (s != null) {
-            int i = className.lastIndexOf('.');
-            if (i != -1) {
-                s.checkPackageAccess(className.substring(0, i));
-            }
-        }
-    }
-
     @SuppressWarnings({"unchecked"})
     static <P> Class<P> nullSafeLoadClass(String className, ClassLoader classLoader) throws ClassNotFoundException {
         if (classLoader == null) { //Match behavior of ServiceLoader
@@ -79,7 +68,6 @@ class ServiceLoaderUtil {
     @SuppressWarnings({"unchecked"})
     static <P> Class<P> safeLoadClass(String className,
                                       ClassLoader classLoader) throws ClassNotFoundException {
-        checkPackageAccess(className);
         return nullSafeLoadClass(className, classLoader);
     }
 


### PR DESCRIPTION
For Jakarta EE 12, the plan is to update all APIs to remove references to the SecurityManager and related APIs in preparation for Java SE 29 which may remove the API or not allow it to be run.

Fixes #125 